### PR TITLE
S3: throttle vacuum

### DIFF
--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -200,7 +200,7 @@ services:
   seaweedfs-volume:
     image: chrislusf/seaweedfs:1.44
     restart: always
-    command: '-v=2 volume -max=1000 -ip=seaweedfs-volume-localnode.tls.ai -mserver=seaweedfs-master-localnode.tls.ai:9333 -port=8080 -dir=/data'
+    command: '-v=2 volume -max=1000 -ip=seaweedfs-volume-localnode.tls.ai -mserver=seaweedfs-master-localnode.tls.ai:9333 -port=8080 -dir=/data -compactionMBps=40'
     networks:
       prod:
         aliases:


### PR DESCRIPTION
volume vacuum is an ongoing background procedure that
copy gigabytes of data, we should throttle the operation so
we will avoid IO starvation.
current limit 40mb, any disk/raid can handle it without big impact.